### PR TITLE
Store Argon2id password hashes on user registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ Server starts on [http://localhost:3000](http://localhost:3000) with file watchi
 |--------|----------|-------------|
 | GET | `/users` | Get all users |
 | GET | `/users/:id` | Get user by ID |
-| POST | `/users` | Create a user |
+| POST | `/users/register` | Register a user |
 | DELETE | `/users/:id` | Delete a user |
+
+Registering a user requires `username`, `email`, and `password`. New users default to the `mentee` role.
 
 ### Posts
 

--- a/codepharos-api.collection.json
+++ b/codepharos-api.collection.json
@@ -3,6 +3,28 @@
     "name": "CodePharos API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:3000",
+      "type": "string"
+    },
+    {
+      "key": "userId",
+      "value": "<user_id>",
+      "type": "string"
+    },
+    {
+      "key": "postId",
+      "value": "<post_id>",
+      "type": "string"
+    },
+    {
+      "key": "commentId",
+      "value": "<comment_id>",
+      "type": "string"
+    }
+  ],
   "item": [
     {
       "name": "Users",
@@ -11,37 +33,25 @@
           "name": "Get all users",
           "request": {
             "method": "GET",
-            "url": "http://localhost:3000/users"
+            "url": "{{baseUrl}}/users"
           }
         },
         {
           "name": "Get user by ID",
           "request": {
             "method": "GET",
-            "url": "http://localhost:3000/users/<user_id>"
+            "url": "{{baseUrl}}/users/{{userId}}"
           }
         },
         {
-          "name": "Create user (mentor)",
+          "name": "Register user",
           "request": {
             "method": "POST",
-            "url": "http://localhost:3000/users",
+            "url": "{{baseUrl}}/users/register",
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"username\": \"janedoe\",\n  \"email\": \"jane@example.com\",\n  \"password\": \"securepassword123\",\n  \"role\": \"mentor\"\n}"
-            }
-          }
-        },
-        {
-          "name": "Create user (mentee)",
-          "request": {
-            "method": "POST",
-            "url": "http://localhost:3000/users",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"username\": \"johndoe\",\n  \"email\": \"john@example.com\",\n  \"password\": \"securepassword456\",\n  \"role\": \"mentee\"\n}"
+              "raw": "{\n  \"username\": \"johndoe\",\n  \"email\": \"john@example.com\",\n  \"password\": \"securepassword456\"\n}"
             }
           }
         },
@@ -49,7 +59,7 @@
           "name": "Delete user",
           "request": {
             "method": "DELETE",
-            "url": "http://localhost:3000/users/<user_id>"
+            "url": "{{baseUrl}}/users/{{userId}}"
           }
         }
       ]
@@ -61,25 +71,25 @@
           "name": "Get all posts",
           "request": {
             "method": "GET",
-            "url": "http://localhost:3000/posts"
+            "url": "{{baseUrl}}/posts"
           }
         },
         {
           "name": "Get post by ID",
           "request": {
             "method": "GET",
-            "url": "http://localhost:3000/posts/<post_id>"
+            "url": "{{baseUrl}}/posts/{{postId}}"
           }
         },
         {
           "name": "Create post",
           "request": {
             "method": "POST",
-            "url": "http://localhost:3000/posts",
+            "url": "{{baseUrl}}/posts",
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"user_id\": \"<user_id>\",\n  \"title\": \"Understanding async/await in JavaScript\",\n  \"content\": \"A promise is just saying I promise I'll return you something eventually...\",\n  \"category\": \"JavaScript\"\n}"
+              "raw": "{\n  \"user_id\": \"{{userId}}\",\n  \"title\": \"Understanding async/await in JavaScript\",\n  \"content\": \"A promise is just saying I promise I'll return you something eventually...\",\n  \"category\": \"JavaScript\"\n}"
             }
           }
         },
@@ -87,7 +97,7 @@
           "name": "Delete post",
           "request": {
             "method": "DELETE",
-            "url": "http://localhost:3000/posts/<post_id>"
+            "url": "{{baseUrl}}/posts/{{postId}}"
           }
         }
       ]
@@ -99,25 +109,25 @@
           "name": "Get all comments",
           "request": {
             "method": "GET",
-            "url": "http://localhost:3000/comments"
+            "url": "{{baseUrl}}/comments"
           }
         },
         {
           "name": "Get comment by ID",
           "request": {
             "method": "GET",
-            "url": "http://localhost:3000/comments/<comment_id>"
+            "url": "{{baseUrl}}/comments/{{commentId}}"
           }
         },
         {
           "name": "Create comment",
           "request": {
             "method": "POST",
-            "url": "http://localhost:3000/comments",
+            "url": "{{baseUrl}}/comments",
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"post_id\": \"<post_id>\",\n  \"user_id\": \"<user_id>\",\n  \"content\": \"Great explanation, this really helped me understand promises!\"\n}"
+              "raw": "{\n  \"post_id\": \"{{postId}}\",\n  \"user_id\": \"{{userId}}\",\n  \"content\": \"Great explanation, this really helped me understand promises!\"\n}"
             }
           }
         },
@@ -125,7 +135,7 @@
           "name": "Delete comment",
           "request": {
             "method": "DELETE",
-            "url": "http://localhost:3000/comments/<comment_id>"
+            "url": "{{baseUrl}}/comments/{{commentId}}"
           }
         }
       ]

--- a/src/database/scripts/setup_db.sql
+++ b/src/database/scripts/setup_db.sql
@@ -1,5 +1,3 @@
-CREATE TYPE user_role as ENUM ('mentor', 'mentee');
-
 CREATE TABLE IF NOT EXISTS users (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     username VARCHAR(128) NOT NULL,
@@ -12,7 +10,7 @@ CREATE TABLE IF NOT EXISTS users (
     password_parallelism INTEGER NOT NULL,
     password_tag_length INTEGER NOT NULL,
     password_pepper_version INTEGER NOT NULL DEFAULT 1,
-    role user_role
+    role user_role NOT NULL DEFAULT 'mentee'
 );
 
 CREATE TABLE IF NOT EXISTS posts (

--- a/src/database/scripts/setup_db.sql
+++ b/src/database/scripts/setup_db.sql
@@ -1,15 +1,16 @@
+CREATE TYPE user_role AS ENUM ('admin', 'mentor', 'mentee');
+
 CREATE TABLE IF NOT EXISTS users (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     username VARCHAR(128) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
     password_hash TEXT NOT NULL,
-    password_nonce TEXT NOT NULL,
+    password_salt TEXT NOT NULL,
     password_algorithm VARCHAR(32) NOT NULL DEFAULT 'argon2id',
     password_memory INTEGER NOT NULL,
     password_passes INTEGER NOT NULL,
     password_parallelism INTEGER NOT NULL,
     password_tag_length INTEGER NOT NULL,
-    password_pepper_version INTEGER NOT NULL DEFAULT 1,
     role user_role NOT NULL DEFAULT 'mentee'
 );
 

--- a/src/database/scripts/setup_db.sql
+++ b/src/database/scripts/setup_db.sql
@@ -4,7 +4,14 @@ CREATE TABLE IF NOT EXISTS users (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     username VARCHAR(128) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
-    password VARCHAR(72) NOT NULL,
+    password_hash TEXT NOT NULL,
+    password_nonce TEXT NOT NULL,
+    password_algorithm VARCHAR(32) NOT NULL DEFAULT 'argon2id',
+    password_memory INTEGER NOT NULL,
+    password_passes INTEGER NOT NULL,
+    password_parallelism INTEGER NOT NULL,
+    password_tag_length INTEGER NOT NULL,
+    password_pepper_version INTEGER NOT NULL DEFAULT 1,
     role user_role
 );
 
@@ -33,4 +40,3 @@ CREATE TABLE IF NOT EXISTS comments (
         FOREIGN KEY(user_id)
             REFERENCES users(id)
 );
-

--- a/src/server/controllers/usersController.js
+++ b/src/server/controllers/usersController.js
@@ -17,7 +17,6 @@ export async function create(req, res) {
   res.status(201).json({
     id: user.id,
     username: user.username,
-    role: user.role,
   });
 }
 

--- a/src/server/controllers/usersController.js
+++ b/src/server/controllers/usersController.js
@@ -1,4 +1,5 @@
 import * as usersQueries from "../queries/usersQueries.js";
+import * as usersService from "../services/usersService.js";
 
 export async function getAll(req, res) {
   const users = await usersQueries.getAll();
@@ -11,8 +12,13 @@ export async function getById(req, res) {
 }
 
 export async function create(req, res) {
-  const user = await usersQueries.create(req.body);
-  res.status(201).json(user);
+  const encryptedObj = await usersService.hashPassword(req.body.password);
+  const user = await usersQueries.create(req.body, encryptedObj);
+  res.status(201).json({
+    id: user.id,
+    username: user.username,
+    role: user.role,
+  });
 }
 
 export async function remove(req, res) {

--- a/src/server/queries/usersQueries.js
+++ b/src/server/queries/usersQueries.js
@@ -9,21 +9,20 @@ export function getById(id) {
 }
 
 export function create(
-  { username, email, role },
-  { hash, nonce, memory, passes, parallelism, tagLength },
+  { username, email },
+  { hash, salt, memory, passes, parallelism, tagLength },
 ) {
   return db.one(
-    "INSERT INTO users (username, email, password_hash, password_nonce, password_memory, password_passes, password_parallelism, password_tag_length, role) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id, username, email, role",
+    "INSERT INTO users (username, email, password_hash, password_salt, password_memory, password_passes, password_parallelism, password_tag_length) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id, username, email",
     [
       username,
       email,
       hash,
-      nonce,
+      salt,
       memory,
       passes,
       parallelism,
       tagLength,
-      role,
     ],
   );
 }

--- a/src/server/queries/usersQueries.js
+++ b/src/server/queries/usersQueries.js
@@ -8,10 +8,23 @@ export function getById(id) {
   return db.one("SELECT * FROM users WHERE id = $1", [id]);
 }
 
-export function create({ username, email, password, role }) {
+export function create(
+  { username, email, role },
+  { hash, nonce, memory, passes, parallelism, tagLength },
+) {
   return db.one(
-    "INSERT INTO users (username, email, password, role) VALUES ($1, $2, $3, $4) RETURNING *",
-    [username, email, password, role],
+    "INSERT INTO users (username, email, password_hash, password_nonce, password_memory, password_passes, password_parallelism, password_tag_length, role) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id, username, email, role",
+    [
+      username,
+      email,
+      hash,
+      nonce,
+      memory,
+      passes,
+      parallelism,
+      tagLength,
+      role,
+    ],
   );
 }
 

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -10,7 +10,7 @@ router.get("/:id", usersController.getById);
 
 router.post(
   "/register",
-  validateSensitive(["username", "email", "password", "role"]),
+  validateSensitive(["username", "email", "password"]),
   usersController.create,
 );
 

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -9,7 +9,7 @@ router.get("/", usersController.getAll);
 router.get("/:id", usersController.getById);
 
 router.post(
-  "/",
+  "/register",
   validateSensitive(["username", "email", "password", "role"]),
   usersController.create,
 );

--- a/src/server/services/usersService.js
+++ b/src/server/services/usersService.js
@@ -1,11 +1,11 @@
 import { argon2, randomBytes } from "node:crypto";
 
 export function hashPassword(password) {
-  const nonce = randomBytes(16);
+  const salt = randomBytes(16);
 
   const parameters = {
     message: password,
-    nonce,
+    nonce: salt,
     parallelism: 4,
     tagLength: 64,
     memory: 65536,
@@ -20,8 +20,8 @@ export function hashPassword(password) {
       }
 
       resolve({
-        hash: derivedKey.toString("hex"),
-        nonce: nonce.toString("base64"),
+        hash: derivedKey.toString("base64"),
+        salt: salt.toString("base64"),
         parallelism: parameters.parallelism,
         tagLength: parameters.tagLength,
         memory: parameters.memory,

--- a/src/server/services/usersService.js
+++ b/src/server/services/usersService.js
@@ -1,0 +1,32 @@
+import { argon2, randomBytes } from "node:crypto";
+
+export function hashPassword(password) {
+  const nonce = randomBytes(16);
+
+  const parameters = {
+    message: password,
+    nonce,
+    parallelism: 4,
+    tagLength: 64,
+    memory: 65536,
+    passes: 3,
+  };
+
+  return new Promise((resolve, reject) => {
+    argon2("argon2id", parameters, (err, derivedKey) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve({
+        hash: derivedKey.toString("hex"),
+        nonce: nonce.toString("base64"),
+        parallelism: parameters.parallelism,
+        tagLength: parameters.tagLength,
+        memory: parameters.memory,
+        passes: parameters.passes,
+      });
+    });
+  });
+}


### PR DESCRIPTION
# Summary
- Added `usersService.hashPassword` to generate Argon2id password hashes with a random nonce and persisted hash parameters.
- Updated user registration flow so the controller hashes incoming passwords before passing data to `usersQueries.create`.
- Updated the users table schema to store password hash metadata instead of plaintext passwords.
- Changed the user creation route from `POST /users` to `POST /users/register` and avoids returning password data in the response.