### PR TITLE
feat: compare password hashes

### DIFF
--- a/src/server/controllers/usersController.js
+++ b/src/server/controllers/usersController.js
@@ -1,19 +1,23 @@
 import * as usersQueries from "../queries/usersQueries.js";
 import * as usersService from "../services/usersService.js";
 
-export async function getAll(req, res) {
-  const users = await usersQueries.getAll();
-  res.status(200).json(users);
-}
-
-export async function getById(req, res) {
-  const user = await usersQueries.getById(req.params.id);
-  res.status(200).json(user);
+export async function getByEmail(req, res) {
+  console.log(req.body)
+  const user = await usersQueries.getByEmail(req.body.email);
+  const hashObj = await usersService.hashPassword(
+    req.body.password,
+    Buffer.from(user.password_salt, "base64"),
+  );
+  const userVerify = usersService.compareHash(
+    user.password_hash,
+    hashObj.hash,
+  );
+  userVerify ? res.status(200).json(userVerify) : res.status(401).send(userVerify);
 }
 
 export async function create(req, res) {
-  const encryptedObj = await usersService.hashPassword(req.body.password);
-  const user = await usersQueries.create(req.body, encryptedObj);
+  const hashObj = await usersService.hashPassword(req.body.password);
+  const user = await usersQueries.create(req.body, hashObj);
   res.status(201).json({
     id: user.id,
     username: user.username,

--- a/src/server/queries/usersQueries.js
+++ b/src/server/queries/usersQueries.js
@@ -1,11 +1,7 @@
 import db from "../../database/index.js";
 
-export function getAll() {
-  return db.many("SELECT * FROM users");
-}
-
-export function getById(id) {
-  return db.one("SELECT * FROM users WHERE id = $1", [id]);
+export function getByEmail(email) {
+  return db.one("SELECT * FROM users WHERE email = $1", [email]);
 }
 
 export function create(

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -1,12 +1,14 @@
 import express from "express";
-import { validateSensitive } from "../middleware/validate.js";
+import { validate, validateSensitive } from "../middleware/validate.js";
 import * as usersController from "../controllers/usersController.js";
 
 const router = express.Router();
 
-router.get("/", usersController.getAll);
-
-router.get("/:id", usersController.getById);
+router.post(
+  "/login",
+  validate(["email", "password"]),
+  usersController.getByEmail,
+);
 
 router.post(
   "/register",

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -1,12 +1,12 @@
 import express from "express";
-import { validate, validateSensitive } from "../middleware/validate.js";
+import { validateSensitive } from "../middleware/validate.js";
 import * as usersController from "../controllers/usersController.js";
 
 const router = express.Router();
 
 router.post(
   "/login",
-  validate(["email", "password"]),
+  validateSensitive(["email", "password"]),
   usersController.getByEmail,
 );
 

--- a/src/server/services/usersService.js
+++ b/src/server/services/usersService.js
@@ -1,7 +1,7 @@
-import { argon2, randomBytes } from "node:crypto";
+import { argon2, randomBytes, timingSafeEqual } from "node:crypto";
 
-export function hashPassword(password) {
-  const salt = randomBytes(16);
+export function hashPassword(password, passed_salt) {
+  const salt = passed_salt ? passed_salt : randomBytes(16);
 
   const parameters = {
     message: password,
@@ -29,4 +29,12 @@ export function hashPassword(password) {
       });
     });
   });
+}
+
+export function compareHash(storedHash, generatedHash) {
+  const stored = Buffer.from(storedHash, "base64");
+  const generated = Buffer.from(generatedHash, "base64");
+  return (
+    stored.length === generated.length && timingSafeEqual(stored, generated)
+  );
 }


### PR DESCRIPTION
## Summary

- Add `POST /users/login` with required `email` and `password` validation.
- Update login flow to look up users by email instead of ID.
- Compare submitted passwords by hashing with the stored salt and checking against the stored password hash.
- Add constant-time password hash comparison with `timingSafeEqual`.
- Update password hashing to support either generating a new salt or reusing an existing stored salt.
- Remove the previous user list/get-by-id routes from `usersRouter`.
